### PR TITLE
Populated the value of piece_bb[NO_PIECE]

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -109,6 +109,7 @@ void Position::move_piece(Square from, Square to) {
 	hash ^= zobrist::zobrist_table[board[from]][from] ^ zobrist::zobrist_table[board[from]][to]
 		^ zobrist::zobrist_table[board[to]][to];
 	Bitboard mask = SQUARE_BB[from] | SQUARE_BB[to];
+	piece_bb[NO_PIECE] = SQUARE_BB[from] | piece_bb[NO_PIECE]& ~SQUARE_BB[to];
 	piece_bb[board[from]] ^= mask;
 	piece_bb[board[to]] &= ~mask;
 	board[to] = board[from];
@@ -118,7 +119,9 @@ void Position::move_piece(Square from, Square to) {
 //Moves a piece to an empty square. Note that it is an error if the <to> square contains a piece
 void Position::move_piece_quiet(Square from, Square to) {
 	hash ^= zobrist::zobrist_table[board[from]][from] ^ zobrist::zobrist_table[board[from]][to];
-	piece_bb[board[from]] ^= (SQUARE_BB[from] | SQUARE_BB[to]);
+	Bitboard mask = SQUARE_BB[from] | SQUARE_BB[to];
+	piece_bb[board[from]] ^= mask;
+	piece_bb[NO_PIECE] ^= mask;
 	board[to] = board[from];
 	board[from] = NO_PIECE;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -89,6 +89,7 @@ public:
 		hash(0), pinned(0), checkers(0) {
 		
 		//Sets all squares on the board as empty
+		piece_bb[NO_PIECE] =~piece_bb[NO_PIECE];
 		for (int i = 0; i < 64; i++) board[i] = NO_PIECE;
 		history[0] = UndoInfo();
 	}
@@ -98,6 +99,7 @@ public:
 	inline void put_piece(Piece pc, Square s) {
 		board[s] = pc;
 		piece_bb[pc] |= SQUARE_BB[s];
+		piece_bb[NO_PIECE] &= ~SQUARE_BB[s];
 		hash ^= zobrist::zobrist_table[pc][s];
 	}
 
@@ -105,6 +107,7 @@ public:
 	inline void remove_piece(Square s) {
 		hash ^= zobrist::zobrist_table[board[s]][s];
 		piece_bb[board[s]] &= ~SQUARE_BB[s];
+		piece_bb[NO_PIECE] |= SQUARE_BB[s];
 		board[s] = NO_PIECE;
 	}
 
@@ -369,7 +372,7 @@ Move* Position::generate_legals(Move* list) {
 
 	const Bitboard us_bb = all_pieces<Us>();
 	const Bitboard them_bb = all_pieces<Them>();
-	const Bitboard all = us_bb | them_bb;
+	const Bitboard all = ~piece_bb[NO_PIECE];
 
 	const Square our_king = bsf(bitboard_of(Us, KING));
 	const Square their_king = bsf(bitboard_of(Them, KING));


### PR DESCRIPTION
The idea was to make piece_bb[NO_PIECE] usable. It is not required for move generation, as it can always be derived form other bit boards. However, I have found not having this value readily accessible to be unintuitive.

It is initialized to all '1's in default Position constructor;
The value is updated in put_piece, remove_piece, move_piece and move_piece_quiet methods
Updated generate_legals and ran perft to validate correct behavior.

Hopefully i have not missed anything